### PR TITLE
Add Relational NetKAT POPL '26 paper to NetKAT website

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -443,6 +443,13 @@
                 
                 <div class="papers-grid">
                     <div class="paper">
+                        <h4><a href="#" target="_blank">Network Change Validation with Relational NetKAT</a></h4>
+                        <p class="authors">Han Xu, David Walker, Ratul Mahajan, Zachary Kincaid</p>
+                        <p class="venue">To appear at POPL 2026</p>
+                        <p class="summary">Introduces Relational NetKAT, which extends NetKAT with a sublanguage of trace relations for expressing desired changes in network behavior.</p>
+                    </div>
+
+                    <div class="paper">
                         <h4><a href="https://doi.org/10.1145/3729295" target="_blank">Active Learning of Symbolic NetKAT Automata</a></h4>
                         <p class="authors">Mark Moeller, Tiago Ferreira, Thomas Lu, Nate Foster, Alexandra Silva</p>
                         <p class="venue">PLDI 2025 • <a href="https://doi.org/10.1145/3729295" target="_blank">DOI</a></p>
@@ -644,6 +651,15 @@
                     </div>
                     <div class="person">
                         <h4>David Walker</h4>
+                    </div>
+                    <div class="person">
+                        <h4>Han Xu</h4>
+                    </div>
+                    <div class="person">
+                        <h4>Ratul Mahajan</h4>
+                    </div>
+                    <div class="person">
+                        <h4>Zachary Kincaid</h4>
                     </div>
                     <div class="person">
                         <h4>Lily Saada</h4>


### PR DESCRIPTION
There is a NetKAT paper in the [POPL '26 accepted paper list ](https://popl26.sigplan.org/track/POPL-2026-popl-research-papers)-- this PR adds it to the NetKAT website! 

(Not sure what steps are needed to deploy the website so I figured I'd make a PR)